### PR TITLE
Check if children exist when filtering axioms

### DIFF
--- a/frontend/public/js/proof/axioms.js
+++ b/frontend/public/js/proof/axioms.js
@@ -51,7 +51,7 @@ export class AxiomsHelper {
 	addShowPrevious() {
 		const { BOX_HEIGHT, BTN_CIRCLE_SIZE } = nodeVisualsDefaults;
 		let group = this.axioms
-			.filter(d => proof.showRules ? d._children[0]._children : d._children) //remove tautologies
+			.filter(d => proof.showRules ? d._children?.[0]._children : d._children) //remove tautologies
 			.append("g").attr("id", "B1")
 			.attr("class", "axiomButton btn-round")
 			.attr("transform", d => `translate(${d.width / 2}, ${BOX_HEIGHT})`)
@@ -104,7 +104,7 @@ export class AxiomsHelper {
 		const { BTN_CIRCLE_SIZE } = nodeVisualsDefaults;
 
 		let group = this.axioms
-			.filter(d => proof.showRules ? d._children[0]._children : d._children) //remove tautologies
+			.filter(d => proof.showRules ? d._children?.[0]._children : d._children) //remove tautologies
 			.append("g").attr("id", "B2")
 			.attr("class", "axiomButton btn-round")
 			.attr("transform", d => `translate(${d.width / 2 - BTN_CIRCLE_SIZE - 1}, 0)`)
@@ -137,7 +137,7 @@ export class AxiomsHelper {
 		const { BTN_CIRCLE_SIZE } = nodeVisualsDefaults;
 
 		let group = this.axioms
-			.filter(d => proof.showRules ? d._children[0]._children : d._children) //remove tautologies
+			.filter(d => proof.showRules ? d._children?.[0]._children : d._children) //remove tautologies
 			.append("g").attr("id", "B3")
 			.attr("class", "axiomButton btn-round")
 			.attr("transform", d => `translate(${d.width / 2}, 0)`)


### PR DESCRIPTION
At least in my case, some axioms have no children at all (when also showing rules), i.e. `d._children` is `undefined`. Hence, the current code just throws an error when trying to pick the first one. This PR resolves the issue.

There is also the chance that I am slightly misusing the library and that it should actually never be the case that `d._children` is undefined when `showRules` is true, so feel free to tell me if I'm doing something wrong.